### PR TITLE
section 11 handle refresh token

### DIFF
--- a/src/auth/authUtils.js
+++ b/src/auth/authUtils.js
@@ -80,7 +80,12 @@ const authentication = asyncHandler(async (req, res, next) => {
   }
 });
 
+const verifyJWT = async (token, tokenSecret) => {
+  return await JWT.verify(token, tokenSecret);
+};
+
 module.exports = {
   createTokenPair,
   authentication,
+  verifyJWT,
 };

--- a/src/controllers/access.controller.js
+++ b/src/controllers/access.controller.js
@@ -26,6 +26,13 @@ class AccessController {
       metadata: await AccessService.logout(req.keyStore),
     }).send(res);
   };
+
+  handleRefreshToken = async (req, res, next) => {
+    new CREATED({
+      message: "Get token successfully!",
+      metadata: await AccessService.handlerRefreshToken(req.body.refreshToken),
+    }).send(res);
+  };
 }
 
 module.exports = new AccessController();

--- a/src/core/error.response.js
+++ b/src/core/error.response.js
@@ -42,10 +42,19 @@ class NotFoundError extends ErrorResponse {
     super(message, statusCode);
   }
 }
+class ForbiddenError extends ErrorResponse {
+  constructor(
+    message = ReasonPhrases.FORBIDDEN,
+    statusCode = StatusCodes.FORBIDDEN
+  ) {
+    super(message, statusCode);
+  }
+}
 
 module.exports = {
   ConflictRequestError,
   BadRequestError,
   AuthFailureError,
   NotFoundError,
+  ForbiddenError,
 };

--- a/src/routes/access/index.js
+++ b/src/routes/access/index.js
@@ -13,6 +13,12 @@ router.post("/shop/login", asyncHandler(accessController.login));
 
 //authenticate
 router.use(authentication);
+
 router.post("/shop/logout", asyncHandler(accessController.logout));
+
+router.post(
+  "/shop/handleRefreshToken",
+  asyncHandler(accessController.handleRefreshToken)
+);
 
 module.exports = router;

--- a/src/services/keyToken.service.js
+++ b/src/services/keyToken.service.js
@@ -48,6 +48,22 @@ class KeyTokenService {
       _id: new ObjectId(id),
     });
   };
+
+  static findByRefreshTokenUsed = async (refreshToken) => {
+    return await keytokenModel
+      .findOne({ refreshTokensUsed: refreshToken })
+      .lean();
+  };
+
+  static findByRefreshToken = async (refreshToken) => {
+    return await keytokenModel.findOne({ refreshToken });
+  };
+
+  static deleteKeyById = async (userId) => {
+    return await keytokenModel.deleteOne({
+      user: new ObjectId(userId),
+    });
+  };
 }
 
 module.exports = KeyTokenService;


### PR DESCRIPTION
+ khi sử dụng lại refreshToken thì xóa luôn 
+ ko sử dụng lean thì nó trả về object mogon và dùng automic
+ Theo e nghĩ mik k nên bỏ "handlerRefreshToken" ở dưới phần "authentication" vì thằng "handlerRefreshToken" chỉ chịu trách nhiệm phát hiện ra user lạ và cấp token mới. Và mik cx thêm 1 bước xác minh user trong thằng "handlerRefreshToken" này luôn. K biết em nghĩ như vậy đúng không
+ API lấy lại access token truyền refresh token, nhưng đầu vào vẫn phải truyền authorization và truyền access token thì hình như k đúng lắm, e đang hiểu khi access token hết hạn, refresh token được sử dụng. Nếu access token mà expire thì hàm verify của JWT sẽ không còn hợp lệ nữa mà api sẽ k thể lấy được access và refresh token trong trường hợp đó.
Trong trường hợp lấy lại access token này e tháy truyền refreshToken vào header, và trong authorization e thấy qua bước 2 sẽ kiểm tra, nếu là case lấy refersh token sẽ k cần check access token nữa.

![image](https://github.com/PhucDuong-SSS/ecommerce_node/assets/68527941/bbfb733c-2dfd-4c27-a044-89b9c1ea42a5)
